### PR TITLE
Update bpa-rules.json

### DIFF
--- a/BPARules/bpa-rules.json
+++ b/BPARules/bpa-rules.json
@@ -1,9 +1,9 @@
 [
     {
       "ID": "AVOID_FLOATING_POINT_DATA_TYPES",
-      "Name": "[Performance] Do not use floating point data types",
+      "Name": "[Performance] Do not use decimal data type",
       "Category": "Performance",
-      "Description": "The \"Double\" floating point data type should be avoided, as it can result in unpredictable roundoff errors and decreased performance in certain scenarios. Use \"Int64\" or \"Decimal\" where appropriate (but note that \"Decimal\" is limited to 4 digits after the decimal sign).",
+      "Description": "The \"Decimal\" floating point data type should be avoided, as it can result in unpredictable roundoff errors and decreased performance in certain scenarios. Use \"Int64\" or \"Fixed Decimal\" where appropriate (but note that \"Fixed Decimal\" is limited to 4 digits after the decimal sign).",
       "Severity": 2,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "DataType = \"Double\"",
@@ -15,7 +15,7 @@
       "Name": "[Performance] Set IsAvailableInMdx to false on non-attribute columns",
       "Category": "Performance",
       "Description": "To speed up processing time and conserve memory after processing, attribute hierarchies should not be built for columns that are never used for slicing by MDX clients. In other words, all hidden columns that are not used as a Sort By Column or referenced in user hierarchies should have their IsAvailableInMdx property set to false.\r\nReference: https://blog.crossjoin.co.uk/2018/07/02/isavailableinmdx-ssas-tabular/",
-      "Severity": 2,
+      "Severity": 3,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "IsAvailableInMDX\r\nand\r\n(IsHidden or Table.IsHidden)\r\nand\r\nnot UsedInSortBy.Any() \r\nand\r\nnot UsedInHierarchies.Any()\r\nand\r\nnot UsedInVariations.Any()",
       "FixExpression": "IsAvailableInMDX = false",
@@ -106,19 +106,29 @@
       "Name": "[Performance] Remove auto-date table",
       "Category": "Performance",
       "Description": "Avoid using auto-date tables. Make sure to turn off auto-date table in the settings in Power BI Desktop. This will save memory resources. \r\nReference: https://www.youtube.com/watch?v=xu3uDEHtCrg",
-      "Severity": 2,
+      "Severity": 3,
       "Scope": "Table, CalculatedTable",
       "Expression": "ObjectTypeName == \"Calculated Table\"\n\r\nand\r\n\n(\nName.StartsWith(\"DateTableTemplate_\") \n\nor \n\nName.StartsWith(\"LocalDateTable_\")\n)",
       "CompatibilityLevel": 1200
     },
     {
-      "ID": "AVOID_EXCESSIVE_BI-DIRECTIONAL_OR_MANY-TO-MANY_RELATIONSHIPS",
+      "ID": "AVOID_EXCESSIVE_BI-DIRECTIONAL_OR_MANY-TO-MANY_RELATIONSHIPS > 0.2",
       "Name": "[Performance] Avoid excessive bi-directional or many-to-many relationships",
       "Category": "Performance",
       "Description": "Limit use of b-di and many-to-many relationships. This rule flags the model if more than 30% of relationships are bi-di or many-to-many.\r\nReference: https://www.sqlbi.com/articles/bidirectional-relationships-and-ambiguity-in-dax/",
       "Severity": 2,
       "Scope": "Model",
-      "Expression": "(\r\n\nRelationships.Where(CrossFilteringBehavior == CrossFilteringBehavior.BothDirections).Count()\r\n\n+\r\n\nRelationships.Where(FromCardinality.ToString() == \"Many\" && ToCardinality.ToString() == \"Many\").Count()\r\n\n)\r\n\n\n/\r\n\n\nMath.Max(Convert.ToDecimal(Relationships.Count)\n\n,1)> 0.3",
+      "Expression": "(\r\n\nRelationships.Where(CrossFilteringBehavior == CrossFilteringBehavior.BothDirections).Count()\r\n\n+\r\n\nRelationships.Where(FromCardinality.ToString() == \"Many\" && ToCardinality.ToString() == \"Many\").Count()\r\n\n)\r\n\n\n/\r\n\n\nMath.Max(Convert.ToDecimal(Relationships.Count)\n\n,1)> 0.2",
+      "CompatibilityLevel": 1200
+    },
+    {
+      "ID": "AVOID_EXCESSIVE_BI-DIRECTIONAL_OR_MANY-TO-MANY_RELATIONSHIPS > 0.4",
+      "Name": "[Performance] Avoid excessive bi-directional or many-to-many relationships",
+      "Category": "Performance",
+      "Description": "Limit use of b-di and many-to-many relationships. This rule flags the model if more than 30% of relationships are bi-di or many-to-many.\r\nReference: https://www.sqlbi.com/articles/bidirectional-relationships-and-ambiguity-in-dax/",
+      "Severity": 3,
+      "Scope": "Model",
+      "Expression": "(\r\n\nRelationships.Where(CrossFilteringBehavior == CrossFilteringBehavior.BothDirections).Count()\r\n\n+\r\n\nRelationships.Where(FromCardinality.ToString() == \"Many\" && ToCardinality.ToString() == \"Many\").Count()\r\n\n)\r\n\n\n/\r\n\n\nMath.Max(Convert.ToDecimal(Relationships.Count)\n\n,1)> 0.4",
       "CompatibilityLevel": 1200
     },
     {
@@ -136,7 +146,7 @@
       "Name": "[Performance] Consider using aggregations if using Direct Query in Power BI",
       "Category": "Performance",
       "Description": "If using Direct Query in Power BI Premium, you may want to consider using aggregations in order to boost performance.\r\nReference: https://docs.microsoft.com/en-us/power-bi/transform-model/desktop-aggregations",
-      "Severity": 1,
+      "Severity": 2,
       "Scope": "Model",
       "Expression": "Tables.Any(ObjectTypeName == \"Table (DirectQuery)\")\r\nand\r\n\n\nAllColumns.Any(AlternateOf != null) == false\r\nand \r\nDefaultPowerBIDataSourceVersion.ToString() == \"PowerBI_V3\"",
       "CompatibilityLevel": 1200
@@ -200,13 +210,23 @@
       "CompatibilityLevel": 1200
     },
     {
-      "ID": "REDUCE_NUMBER_OF_CALCULATED_COLUMNS",
+      "ID": "REDUCE_NUMBER_OF_CALCULATED_COLUMNS > 5",
       "Name": "[Performance] Reduce number of calculated columns",
       "Category": "Performance",
       "Description": "Calculated columns do not compress as well as data columns so they take up more memory. They also slow down processing times for both the table as well as process recalc. Offload calculated column logic to your data warehouse and turn these calculated columns into data columns.\r\nReference: https://www.elegantbi.com/post/top10bestpractices",
       "Severity": 2,
       "Scope": "Model",
       "Expression": "AllColumns.Where(Type.ToString() == \"Calculated\").Count() > 5",
+      "CompatibilityLevel": 1200
+    },
+    {
+      "ID": "REDUCE_NUMBER_OF_CALCULATED_COLUMNS > 10",
+      "Name": "[Performance] Reduce number of calculated columns",
+      "Category": "Performance",
+      "Description": "Calculated columns do not compress as well as data columns so they take up more memory. They also slow down processing times for both the table as well as process recalc. Offload calculated column logic to your data warehouse and turn these calculated columns into data columns.\r\nReference: https://www.elegantbi.com/post/top10bestpractices",
+      "Severity": 3,
+      "Scope": "Model",
+      "Expression": "AllColumns.Where(Type.ToString() == \"Calculated\").Count() > 10",
       "CompatibilityLevel": 1200
     },
     {
@@ -253,7 +273,7 @@
       "ID": "AVOID_DUPLICATE_MEASURES",
       "Name": "[DAX Expressions] No two measures should have the same definition",
       "Category": "DAX Expressions",
-      "Severity": 2,
+      "Severity": 3,
       "Scope": "Measure",
       "Expression": "Model.AllMeasures.Any(Expression.Replace(\" \",\"\").Replace(\"\\n\",\"\").Replace(\"\\r\",\"\").Replace(\"\\t\",\"\") = outerIt.Expression.Replace(\" \",\"\").Replace(\"\\n\",\"\").Replace(\"\\r\",\"\").Replace(\"\\t\",\"\") and it <> outerIt)",
       "CompatibilityLevel": 1200
@@ -323,7 +343,7 @@
       "Name": "[DAX Expressions] Inactive relationships that are never activated",
       "Category": "DAX Expressions",
       "Description": "Inactive relationships are activated using the USERELATIONSHIP function. If an inactive relationship is not referenced in any measure via this function, the relationship will not be used. It should be determined whether the relationship is not necessary or to activate the relationship via this method.\r\n\r\nReference: https://docs.microsoft.com/power-bi/guidance/relationships-active-inactive\r\nReference: https://dax.guide/userelationship/",
-      "Severity": 2,
+      "Severity": 3,
       "Scope": "Relationship",
       "Expression": "IsActive == false\r\nand not\r\n(\r\nModel.AllMeasures.Any(RegEx.IsMatch(Expression,\r\n\"(?i)USERELATIONSHIP\\s*\\(\\s*\\'*\" +\r\ncurrent.FromTable.Name + \"\\'*\\[\" + \r\ncurrent.FromColumn.Name + \"\\]\\s*,\\s*\\'*\" +\r\ncurrent.ToTable.Name + \"\\'*\\[\" +\r\ncurrent.ToColumn.Name + \"\\]\"))\r\nor\r\nModel.AllCalculationItems.Any(RegEx.IsMatch(Expression,\r\n\"(?i)USERELATIONSHIP\\s*\\(\\s*\\'*\" +\r\ncurrent.FromTable.Name + \"\\'*\\[\" + \r\ncurrent.FromColumn.Name + \"\\]\\s*,\\s*\\'*\" +\r\ncurrent.ToTable.Name + \"\\'*\\[\" +\r\ncurrent.ToColumn.Name + \"\\]\"))\r\n)",
       "CompatibilityLevel": 1200
@@ -415,7 +435,7 @@
       "Name": "[Maintenance] Fix referential integrity violations",
       "Category": "Maintenance",
       "Description": "This rule highlights relationships which have referential integrity violations. This indicates that there are values in the table on the 'from' side of the relationship which do not exist in the table on the 'to' side of the relationship. Referential integrity violations will also produce the 'blank' member value in slicers. It is recommended to fix these issues by ensuring that the 'to' table's primary key column has all the values in the 'from' table's foreign key column.\r\n\r\nReference: https://blog.enterprisedna.co/vertipaq-analyzer-tutorial-relationships-referential-integrity/",
-      "Severity": 2,
+      "Severity": 3,
       "Scope": "Relationship",
       "Expression": "Convert.ToInt64(GetAnnotation(\"Vertipaq_RIViolationInvalidRows\")) > 0",
       "CompatibilityLevel": 1200
@@ -425,7 +445,7 @@
       "Name": "[Maintenance] Remove data sources not referenced by any partitions",
       "Category": "Maintenance",
       "Description": "Data sources which are not referenced by any partitions may be removed.",
-      "Severity": 1,
+      "Severity": 2,
       "Scope": "ProviderDataSource, StructuredDataSource",
       "Expression": "UsedByPartitions.Count() == 0",
       "FixExpression": "Delete()",
@@ -457,7 +477,7 @@
       "Name": "[Maintenance] Visible objects with no description",
       "Category": "Maintenance",
       "Description": "Add descriptions to objects. These descriptions are shown on hover within the Field List in Power BI Desktop. Additionally, you can leverage these descriptions to create an automated data dictionary (see link below).\r\nReference: https://www.elegantbi.com/post/datadictionary",
-      "Severity": 1,
+      "Severity": 2,
       "Scope": "Table, Measure, DataColumn, CalculatedColumn, CalculatedTable, CalculatedTableColumn, CalculationGroup",
       "Expression": "string.IsNullOrWhitespace(Description)\r\nand\r\nIsHidden == false",
       "CompatibilityLevel": 1200
@@ -528,7 +548,7 @@
       "ID": "DATECOLUMN_FORMATSTRING",
       "Name": "[Formatting] Provide format string for \"Date\" columns",
       "Category": "Formatting",
-      "Description": "Columns of type \"DateTime\" that have \"Month\" in their names should be formatted as \"mm/dd/yyyy\".",
+      "Description": "Columns of type \"DateTime\" that have \"Month\" in their names should be formatted as \"dd/mm/yyyy\".",
       "Severity": 1,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "Name.IndexOf(\"Date\", \"OrdinalIgnoreCase\") >= 0 \r\nand \r\nDataType = \"DateTime\" \r\nand \r\nFormatString <> \"mm/dd/yyyy\"",
@@ -602,7 +622,7 @@
       "Name": "[Formatting] Relationship columns should be of integer data type",
       "Category": "Formatting",
       "Description": "It is a best practice for relationship columns to be of integer data type. This applies not only to data warehousing but data modeling as well.",
-      "Severity": 1,
+      "Severity": 2,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "UsedInRelationships.Any()\n\nand \n\nDataType != DataType.Int64",
       "CompatibilityLevel": 1200
@@ -612,7 +632,7 @@
       "Name": "[Formatting] Add data category for columns",
       "Category": "Formatting",
       "Description": "Add Data Category property for appropriate columns.\r\n\r\nReference: https://docs.microsoft.com/en-us/power-bi/transform-model/desktop-data-categorization",
-      "Severity": 1,
+      "Severity": 2,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "string.IsNullOrWhitespace(DataCategory)\r\nand\r\n(\r\n(\r\nName.ToLower().Contains(\"country\")\r\nor \r\n\nName.ToLower().Contains(\"continent\"\n)\r\nor\r\nName.ToLower().Contains(\"city\")\r\n)\r\nand DataType == \"String\"\r\n)\r\nor \r\n(\r\n(\nName.ToLower() == \"latitude\" \n or \nName.ToLower() == \"longitude\")\r\nand (DataType == DataType.Decimal or DataType == DataType.Double)\r\n)",
       "CompatibilityLevel": 1200


### PR DESCRIPTION
- Modified severity levels (more hard stops on performance related rules)
- Modified date format rule to AU format
- Duplicated calculated column rule with higher count threshold and level 3 severity (no change to existing rule) - new version is severity 3 and threshold is > 10
-  Updated description for floating point data types from Decimal to Fixed Decimal to align with PBI context;
-  Duplicated AVOID_EXCESSIVE_BI-DIRECTIONAL_OR_MANY-TO-MANY_RELATIONSHIPS - threshold on new rule is 0.4 and severity is 3
- Existing AVOID_EXCESSIVE_BI-DIRECTIONAL_OR_MANY-TO-MANY_RELATIONSHIPS threshold lowered to 0.2 and severity remains 0.2