### PR TITLE
Update bpa-rules.json

### DIFF
--- a/BPARules/bpa-rules.json
+++ b/BPARules/bpa-rules.json
@@ -541,7 +541,7 @@
       "Severity": 1,
       "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
       "Expression": "Name.IndexOf(\"Date\", \"OrdinalIgnoreCase\") >= 0 \r\nand \r\nDataType = \"DateTime\" \r\nand \r\nFormatString <> \"mm/dd/yyyy\"",
-      "FixExpression": "FormatString = \"mm/dd/yyyy\"",
+      "FixExpression": "FormatString = \"dd/mm/yyyy\"",
       "CompatibilityLevel": 1200
     },
     {


### PR DESCRIPTION
picked up error in "[Formatting] Provide format string for "Date" columns". Previous modificaiton of the original rule modified the description from US to AU format, i.e. from mm/dd/yyyy to dd/mm/yyyy but rule expression was not changed. Correcting that error.